### PR TITLE
Feature/fonestorm casing consistency

### DIFF
--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -83,7 +83,7 @@ except ApiException as e:
 }
 ```
 
-Fonestorm uses an API key to allow access to the API. Fonestorm expects for the API key (also called a "token") to be included in all API requests to the server in a header that looks like the following:
+FoneStorm uses an API key to allow access to the API. FoneStorm expects for the API key (also called a "token") to be included in all API requests to the server in a header that looks like the following:
 
 `token: key`
 

--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -1,10 +1,10 @@
 # Errors
 
-Fonestorm uses conventional HTTP response codes to indicate the success or failure of an API request. Codes in the 2xx range indicate success, codes in the 4xx range indicate an error that failed given the information provided and codes in the 5xx range indicate an error with our servers.
+FoneStorm uses conventional HTTP response codes to indicate the success or failure of an API request. Codes in the 2xx range indicate success, codes in the 4xx range indicate an error that failed given the information provided and codes in the 5xx range indicate an error with our servers.
 
 ## Client Errors
 
-Fonestorm API uses the following HTTP status codes for client errors:
+FoneStorm API uses the following HTTP status codes for client errors:
 
 Code | Error | Description
 ---------- | ------- | -------
@@ -34,7 +34,7 @@ Code | Error | Description
 
 ## Server Errors
 
-Fonestorm API uses the following HTTP status codes for server errors:
+FoneStorm API uses the following HTTP status codes for server errors:
 
 Code | Error | Description
 ---------- | ------- | -------

--- a/source/includes/_fonenumbers.md
+++ b/source/includes/_fonenumbers.md
@@ -1,6 +1,6 @@
-# Fonenumbers
+# FoneNumbers
 
-## List All Fonenumbers
+## List All FoneNumbers
 
 > Example Request
 
@@ -100,7 +100,7 @@ except ApiException as e:
 }
 ```
 
-Get all active Fonenumbers listed under the account.
+Get all active FoneNumbers listed under the account.
 
 ### HTTP Request
 
@@ -123,7 +123,7 @@ The default `filter` value is `fonenumbers`. For a more detailed response you ma
 - `fonenumbers` returns an array of fonenumber strings.
 - `all` returns an array of fonenumber objects.
 
-## Order New Fonenumber
+## Order New FoneNumber
 
 > Example Request
 
@@ -206,7 +206,7 @@ except ApiException as e:
 }
 ```
 
-Order a new Fonenumber for the account.
+Order a new FoneNumber for the account.
 
 ### HTTP Request
 
@@ -221,10 +221,10 @@ Parameter | Type | Default | Description
 area_code | string |  | A valid 3-digit Area Code.
 
 <aside class="notice">
-Adding a Fonenumber to your account may result in additional charges and fees.
+Adding a FoneNumber to your account may result in additional charges and fees.
 </aside>
 
-## Get Fonenumber Details
+## Get FoneNumber Details
 
 > Example Request
 
@@ -322,7 +322,7 @@ except ApiException as e:
 }
 ```
 
-Get information for a single Fonenumber listed under the account.
+Get information for a single FoneNumber listed under the account.
 
 ### HTTP Request
 
@@ -334,9 +334,9 @@ Method | Route
 
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
-fonenumber | string |  | A Fonenumber associated with the account.
+fonenumber | string |  | A FoneNumber associated with the account.
 
-## Update Fonenumber
+## Update FoneNumber
 
 > Example Request
 
@@ -424,7 +424,7 @@ except ApiException as e:
 }
 ```
 
-Configure the service type for account Fonenumber.
+Configure the service type for account FoneNumber.
 
 ### HTTP Request
 
@@ -436,13 +436,13 @@ Method | Route
 
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
-fonenumber | string |  | A Fonenumber associated with the account.
+fonenumber | string |  | A FoneNumber associated with the account.
 
 ### Body Parameters
 
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
-fonenumber | string |  | A Fonenumber associated with the account.
+fonenumber | string |  | A FoneNumber associated with the account.
 type | string |  | Message routing type. Allowed values are `None`, `Device`, `Email`, `URL` or `Forward`.
 value | string |  | Message routing type value.
 url_method<br/>_optional_ | string |  | URL method. Allowed values are `GET`, `POST`, or `JSON`. See Notes for additional information.
@@ -453,13 +453,13 @@ url_password<br/>_optional_ | string |  | URL password for HTTP **Basic** authen
 
 #### `url_method`
 
-When `type` is `URL` then `url_method` is required. The URL `value` is expected to be a valid HTTP or HTTPS URL that will accept data when a message is sent to the Fonenumber. One of three available methods must be specified for the execution.
+When `type` is `URL` then `url_method` is required. The URL `value` is expected to be a valid HTTP or HTTPS URL that will accept data when a message is sent to the FoneNumber. One of three available methods must be specified for the execution.
 
 - `GET` returns data through query string parameters on a `GET` to the given URL.
 - `POST` returns data as _(application/x-www-form-urlencoded)_ in the body of a `POST` to the given URL.
 - `JSON` returns data as _(application/json)_ in the body of a `POST` to the given URL.
 
-## Delete Fonenumber
+## Delete FoneNumber
 
 > Example Request
 
@@ -535,7 +535,7 @@ except ApiException as e:
 }
 ```
 
-Remove Fonenumber from account.
+Remove FoneNumber from account.
 
 ### HTTP Request
 
@@ -547,4 +547,4 @@ Method | Route
 
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
-fonenumber | string |  | A Fonenumber associated with the account.
+fonenumber | string |  | A FoneNumber associated with the account.

--- a/source/includes/_introduction.md
+++ b/source/includes/_introduction.md
@@ -1,14 +1,14 @@
 # Introduction
 
-**Welcome to Fonestorm&trade;, the communications API platform powered by FracTEL!**
+**Welcome to FoneStorm&trade;, the communications API platform powered by FracTEL!**
 
-Fonestorm is compliant with the [OpenAPI Specification](https://www.openapis.org/). You can view code examples in the right column and you can switch the programming language of the examples with the tabs in the top right.
+FoneStorm is compliant with the [OpenAPI Specification](https://www.openapis.org/). You can view code examples in the right column and you can switch the programming language of the examples with the tabs in the top right.
 
-The Fonestorm API is organized around [REST](http://en.wikipedia.org/wiki/Representational_State_Transfer). We utilize built-in HTTP features, such as HTTP authentication and HTTP verbs, which are understood by off-the-shelf HTTP clients. [JSON](http://www.json.org/) is returned by all API responses, including errors.
+The FoneStorm API is organized around [REST](http://en.wikipedia.org/wiki/Representational_State_Transfer). We utilize built-in HTTP features, such as HTTP authentication and HTTP verbs, which are understood by off-the-shelf HTTP clients. [JSON](http://www.json.org/) is returned by all API responses, including errors.
 
-## Using Fonestorm
+## Using FoneStorm
 
-You will need an active FracTEL account with API access enabled to use the Fonestorm API. Call us at (321) 499-1000 or email [sales@fonestorm.com](mailto:sales@fonestorm.com?subject=FracTEL%20API%20Access%20Request) to get set up.
+You will need an active FracTEL account with API access enabled to use the FoneStorm API. Call us at (321) 499-1000 or email [sales@fonestorm.com](mailto:sales@fonestorm.com?subject=FracTEL%20API%20Access%20Request) to get set up.
 
 All operations are scoped to the FracTEL account being used to authenticate. Whenever this documentation makes reference to "the account" or "your account", it is referring to the account that was used to obtain the API key.
 
@@ -20,19 +20,19 @@ All URLs referenced in the documentation have the following base:
 
 ## Fonenumbers
 
-A Fonenumber&trade; is an all-purpose communication service routing handle provided by FracTEL. A fonenumber is an actual telephone number and it can be called or messaged from any landline or mobile telephone. It can be configured to route voice calls, faxes and SMS/MMS messages to another telephone, however a fonenumber is capable of much more -- and this power is exposed  through the Fonestorm API platform.
+A Fonenumber&trade; is an all-purpose communication service routing handle provided by FracTEL. A fonenumber is an actual telephone number and it can be called or messaged from any landline or mobile telephone. It can be configured to route voice calls, faxes and SMS/MMS messages to another telephone, however a fonenumber is capable of much more -- and this power is exposed  through the FoneStorm API platform.
 
 ## Dates and Times
 
-Representation of dates and times are in [Coordinated Universal Time](https://en.wikipedia.org/wiki/Coordinated_Universal_Time) (_UTC_). The Fonestorm API accepts and returns dates and times that are represented using [ISO 8601](https://www.w3.org/TR/NOTE-datetime) formats.
+Representation of dates and times are in [Coordinated Universal Time](https://en.wikipedia.org/wiki/Coordinated_Universal_Time) (_UTC_). The FoneStorm API accepts and returns dates and times that are represented using [ISO 8601](https://www.w3.org/TR/NOTE-datetime) formats.
 
 ## Rate limiting
 
-Standard Fonestorm accounts are limited to 10 requests per second. Some services impose additional rate limits; please check the documentation carefully. Requests that exceed these limits will be rejected. Contact us if your project requires a higher transaction rate.
+Standard FoneStorm accounts are limited to 10 requests per second. Some services impose additional rate limits; please check the documentation carefully. Requests that exceed these limits will be rejected. Contact us if your project requires a higher transaction rate.
 
 ## Sample Code and API Clients
 
-Fonestorm clients are available in a variety of languages and environments at the [client repository](https://github.com/fractel/fonestorm-clients):
+FoneStorm clients are available in a variety of languages and environments at the [client repository](https://github.com/fractel/fonestorm-clients):
 
 - Bash
 - C#
@@ -52,4 +52,4 @@ Code examples throughout this documentation, with the exception of cURL examples
 
 ## Terms and Conditions
 
-Your use of the Fonestorm API is subject to certain [Terms and Conditions](https://www.fractel.net/terms-and-conditions/), and some API calls will allocate resources or perform tasks that incur usage fees and/or charges. You are responsible for understanding these Terms and Conditions and any and all costs associated with use or misuse of the Fonestorm API.
+Your use of the FoneStorm API is subject to certain [Terms and Conditions](https://www.fractel.net/terms-and-conditions/), and some API calls will allocate resources or perform tasks that incur usage fees and/or charges. You are responsible for understanding these Terms and Conditions and any and all costs associated with use or misuse of the FoneStorm API.

--- a/source/includes/_introduction.md
+++ b/source/includes/_introduction.md
@@ -18,9 +18,9 @@ All URLs referenced in the documentation have the following base:
 
 `https://api.fonestorm.com/v2`
 
-## Fonenumbers
+## FoneNumbers
 
-A Fonenumber&trade; is an all-purpose communication service routing handle provided by FracTEL. A fonenumber is an actual telephone number and it can be called or messaged from any landline or mobile telephone. It can be configured to route voice calls, faxes and SMS/MMS messages to another telephone, however a fonenumber is capable of much more -- and this power is exposed  through the FoneStorm API platform.
+A FoneNumber&trade; is an all-purpose communication service routing handle provided by FracTEL. A fonenumber is an actual telephone number and it can be called or messaged from any landline or mobile telephone. It can be configured to route voice calls, faxes and SMS/MMS messages to another telephone, however a fonenumber is capable of much more -- and this power is exposed  through the FoneStorm API platform.
 
 ## Dates and Times
 

--- a/source/includes/_messages.md
+++ b/source/includes/_messages.md
@@ -179,7 +179,7 @@ Message sending confirmation callback URLs receive JSON data via a <code>POST</c
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
 to | string | | Phone number of recipient.
-from | string | | Fonenumber of sender.
+from | string | | FoneNumber of sender.
 message | string | | Contents of the message.
 deliverystate | string | | Delivery state of the message. Potential values are `waiting`, `delivered` or  `not-delivered`.
 deliverycode | int | | Delivery code of the message. Potential values are: <ul><li>`000` - Message delivered to carrier</li><li>`100` - Message not delivered to carrier</li><li>`187` - Statistical spam detected</li><li>`188` - Keyword spam detected</li><li>`189` - Spam detected</li><li>`482` - Loop detected</li><li>`600` - Destination carrier could not accept messages</li><li>`610` - Message submission failed</li><li>`620` - Destination application error</li><li>`630` - Message not acknowledged</li><li>`720` - Invalid destination number</li><li>`740` - Invalid source number</li><li>`999` - Unknown error</li></ul>
@@ -297,7 +297,7 @@ Method | Route
 
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
-from | string |  | A Fonenumber associated with the account.
+from | string |  | A FoneNumber associated with the account.
 url | string | | Callback URL. See **Notes** for additional information.
 method | string | | Allowed values are `GET`,`POST`, or `JSON`. See **Notes** for additional information.
 
@@ -320,7 +320,7 @@ One of three available methods must be specified for the callback execution.
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
 to | string | | Phone number of recipient.
-from | string | | Fonenumber of sender.
+from | string | | FoneNumber of sender.
 message | string | | Contents of the message.
 uid | string | | Unique identifier for the message.
 
@@ -426,7 +426,7 @@ Method | Route
 
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
-to | string |  | A Fonenumber associated with the account.
+to | string |  | A FoneNumber associated with the account.
 type | string | | Message service routing type. Allowed values are `Device`, `Email`, `URL`, `Forward`, or `None`. See **Notes** for additional information.
 value | string | | Value of the chosen message routing type. Allows for a _Device ID_, _Email Address_, _URL_ or _Phone Number_ depending on the specified `type`. See **Notes** for additional information.
 
@@ -452,7 +452,7 @@ None    | _None_                           |
 
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
-to | string | | Fonenumber of recipient.
+to | string | | FoneNumber of recipient.
 from | string | | Phone number of sender.
 message | string | | Contents of the message.
 uid | string | | Unique identifier for the message.
@@ -562,7 +562,7 @@ Method | Route
 
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
-to | string |  | A Fonenumber associated with the account.
+to | string |  | A FoneNumber associated with the account.
 url | string | | Callback URL. See **Notes** for additional information.
 method | string | | Allowed values are `GET`,`POST`, or `JSON`. See **Notes** for additional information.
 
@@ -584,7 +584,7 @@ One of three available methods must be specified for the callback execution.
 
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
-to | string | | Fonenumber of recipient.
+to | string | | FoneNumber of recipient.
 from | string | | Phone number of sender.
 message | string | | Contents of the message.
 uid | string | | Unique identifier for the message.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1,5 +1,5 @@
 ---
-title: Fonestorm API 2.1.1
+title: FoneStorm API 2.1.1
 
 language_tabs:
   - shell: cURL


### PR DESCRIPTION
Use consistent spelling of `FoneStorm` and `FoneNumber`.