### PR TITLE
Fix/documentation

### DIFF
--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -13,8 +13,8 @@ $ curl --request POST
 
 ```javascript
 // Obtain an authentication token that is valid for two hours.
-var FracTelApi212 = require('frac_tel_api_212');
-var apiInstance = new FracTelApi212.AuthApi();
+var FracTelApi = require('frac_tel_api_212');
+var apiInstance = new FracTelApi.AuthApi();
 var username = "xxxxxxxxxx";
 var password = "xxxxxxxxxx";
 var opts = {

--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -13,8 +13,8 @@ $ curl --request POST
 
 ```javascript
 // Obtain an authentication token that is valid for two hours.
-var FracTelApi210 = require('frac_tel_api_210');
-var apiInstance = new FracTelApi210.AuthApi();
+var FracTelApi212 = require('frac_tel_api_212');
+var apiInstance = new FracTelApi212.AuthApi();
 var username = "xxxxxxxxxx";
 var password = "xxxxxxxxxx";
 var opts = {
@@ -117,5 +117,5 @@ token | string | Generated token used for making additional requests.
 expires | datetime | UTC expiration time of token.
 
 <aside class="notice">
-API calls that use invalid or expired tokens will receive a response of `401 - Unauthorized`.
+API calls that use invalid or expired tokens will receive a response of <code>401 - Unauthorized</code>.
 </aside>

--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -107,6 +107,15 @@ username | string |  |FracTEL username.
 password | string | | FracTEL password.
 expires<br/>_optional_ | integer | 3600 | Token time to live in seconds. The maximum allowed time is 24 hours.
 
+### Response Properties
+
+Property | Type | Description
+--------- | ------- | -----------
+status_code | integer | HTTP status code.
+result | string | Text result of the request.
+token | string | Generated token used for making additional requests.
+expires | datetime | UTC expiration time of token.
+
 <aside class="notice">
 API calls that use invalid or expired tokens will receive a response of `401 - Unauthorized`.
 </aside>

--- a/source/includes/_fonenumbers.md
+++ b/source/includes/_fonenumbers.md
@@ -72,26 +72,27 @@ except ApiException as e:
   "status_code": 200,
   "fonenumbers": [
     {
-      "fonenumber": "8889807630",
-      "service_type": "TimeOfDayRoute",
-      "receive": {
-        "type": "URL",
-        "email": "",
-        "device": "",
-        "forward": "",
-        "url": "https://hookb.in/Ew7WzAb2",
-        "url_method": "JSON"
+      "fonenumber": "3215551111",
+      "sms_options": {
+        "receive": {
+          "type": "email",
+          "email": "support@domain.com",
+          "device": "987123543678",
+          "forward": "3215553333",
+          "url": "https://hookb.in/KlwpR3j5",
+          "url_method": "JSON"
+        },
+        "receive_notify": {
+          "url": "https://hookbin.com/bin/KNRzy7P3",
+          "method": "JSON"
+        },
+        "send_notify": {
+          "url": "https://hookb.in/vewOPNyB",
+          "method": "JSON"
+        },
+        "sms_enabled": "yes",
+        "mms_enabled": "yes"
       },
-      "receive_notify": {
-        "url": "https://hookb.in/Ew7WzAb2",
-        "method": "JSON"
-      },
-      "send_notify": {
-        "url": "https://hookb.in/Ew7WzAb2",
-        "method": "JSON"
-      },
-      "sms_enabled": "no",
-      "mms_enabled": "no",
       "is_active": "yes"
     }
   ],
@@ -113,6 +114,23 @@ Method | Route
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
 filter | string | fonenumbers | Filter the response attributes. Allowed values are `fonenumbers` or `all`. See Notes for additional information.
+
+### Response Properties
+
+Property | Type | Description
+--------- | ------- | -----------
+status_code | integer | HTTP status code.
+result | string | Text result of the request.
+total | integer | Total number of account FoneNumbers listed.
+fonenumbers | array | Array of account FoneNumbers.
+fonenumber | string | FoneNumber.
+sms_options | object | SMS related properties.
+receive | object | Delivery service type used as the destination to receive messages. <ul><li>`type` - service type</li><li>`email` - email address if configured for email</li><li>`device` - FracTEL device if configured for device</li><li>`forward` - telephone number if configured for forward</li><li>`url` - HTTP URL if configured for URL</li><li>`url_method` - HTTP URL method if configured for URL</li></ul>
+receive_notify | object | Callback URL to notify when a message is received. <ul><li>`url` - HTTP URL</li><li>`url_method` - HTTP URL method</li></ul>
+send_notify | object | Callback URL to notify when a message is sent. <ul><li>`url` - HTTP URL</li><li>`url_method` - HTTP URL method</li></ul>
+sms_enabled | string | FoneNumber is enabled for SMS service.
+mms_enabled | string | FoneNumber is enabled for MMS service.
+is_active | string | Status of FoneNumber. Potenial values are: <ul><li>`yes` - active</li><li>`no` - pending cancellation</li><li>`cancel` - cancelled</li></ul>.
 
 ### Notes
 
@@ -196,7 +214,7 @@ except ApiException as e:
 {
   "status_code": 200,
   "fonenumber": {
-    "fonenumber": "3212335701",
+    "fonenumber": "3215551111",
     "sms_enabled": "yes",
     "mms_enabled": "yes",
     "state": "FL",
@@ -224,24 +242,36 @@ area_code | string |  | A valid 3-digit Area Code.
 Adding a FoneNumber to your account may result in additional charges and fees.
 </aside>
 
+### Response Properties
+
+Property | Type | Description
+--------- | ------- | -----------
+status_code | integer | HTTP status code.
+result | string | Text result of the request.
+fonenumber | string | FoneNumber.
+sms_enabled | string | FoneNumber is enabled for SMS service.
+mms_enabled | string | FoneNumber is enabled for MMS service.
+state | string | State FoneNumber is registered.
+rate_center | string | Rate center for the FoneNumber.
+
 ## Get FoneNumber Details
 
 > Example Request
 
 ```shell
-# Get details for FoneNumber `3212182662`
+# Get details for FoneNumber `3215551111`
 $ curl --request GET
---url 'https://api.fonestorm.com/v2/fonenumbers/3212182662'
+--url 'https://api.fonestorm.com/v2/fonenumbers/3215551111'
 --header 'Content-Type: application/json'
 --header 'Accept: application/json'
 --header 'token: key'
 ```
 
 ```javascript
-// Get details for FoneNumber `3212182662`
+// Get details for FoneNumber `3215551111`
 var FracTelApi211 = require('frac_tel_api_211');
 var apiInstance = new FracTelApi210.FonenumbersApi();
-var fonenumber = "3212182662";
+var fonenumber = "3215551111";
 
 var callback = function(error, data, response) {
   if (error) {
@@ -255,11 +285,11 @@ apiInstance.getFonenumbersFonenumber(fonenumber, callback);
 
 ```php
 <?php
-// Get details for FoneNumber `3212182662`
+// Get details for FoneNumber `3215551111`
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new Swagger\Client\Api\FonenumbersApi();
-$fonenumber = "3212182662";
+$fonenumber = "3215551111";
 
 try {
     $result = $api_instance->getFonenumbersFonenumber($fonenumber);
@@ -271,7 +301,7 @@ try {
 ```
 
 ```python
-# Get details for FoneNumber `3212182662`
+# Get details for FoneNumber `3215551111`
 from __future__ import print_function
 import time
 import swagger_client
@@ -280,7 +310,7 @@ from pprint import pprint
 
 # create an instance of the API class
 api_instance = swagger_client.FonenumbersApi()
-fonenumber = '3212182662' # str | Your FracTEL fonenumber.
+fonenumber = '3215551111' # str | Your FracTEL fonenumber.
 
 try:
     # Get a single FoneNumber listed under the account.
@@ -296,26 +326,27 @@ except ApiException as e:
 {
   "status_code": 200,
   "fonenumber": {
-    "fonenumber": "8889807630",
-    "service_type": "TimeOfDayRoute",
-    "receive": {
-      "type": "URL",
-      "email": "",
-      "device": "",
-      "forward": "",
-      "url": "https://hookb.in/Ew7WzAb2",
-      "url_method": "JSON"
+    "fonenumber": "3215551111",
+    "sms_options": {
+      "receive": {
+        "type": "email",
+        "email": "support@domain.com",
+        "device": "987123543678",
+        "forward": "3215553333",
+        "url": "https://hookb.in/KlwpR3j5",
+        "url_method": "JSON"
+      },
+      "receive_notify": {
+        "url": "https://hookbin.com/bin/KNRzy7P3",
+        "method": "JSON"
+      },
+      "send_notify": {
+        "url": "https://hookb.in/vewOPNyB",
+        "method": "JSON"
+      },
+      "sms_enabled": "yes",
+      "mms_enabled": "yes"
     },
-    "receive_notify": {
-      "url": "https://hookb.in/Ew7WzAb2",
-      "method": "JSON"
-    },
-    "send_notify": {
-      "url": "https://hookb.in/Ew7WzAb2",
-      "method": "JSON"
-    },
-    "sms_enabled": "no",
-    "mms_enabled": "no",
     "is_active": "yes"
   },
   "result": "SUCCESS"
@@ -336,15 +367,30 @@ Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
 fonenumber | string |  | A FoneNumber associated with the account.
 
+### Response Properties
+
+Property | Type | Description
+--------- | ------- | -----------
+status_code | integer | HTTP status code.
+result | string | Text result of the request.
+fonenumber | string | FoneNumber.
+sms_options | object | SMS related properties.
+receive | object | Delivery service type used as the destination to receive messages. <ul><li>`type` - service type</li><li>`email` - email address if configured for email</li><li>`device` - FracTEL device if configured for device</li><li>`forward` - telephone number if configured for forward</li><li>`url` - HTTP URL if configured for URL</li><li>`url_method` - HTTP URL method if configured for URL</li></ul>
+receive_notify | object | Callback URL to notify when a message is received. <ul><li>`url` - HTTP URL</li><li>`url_method` - HTTP URL method</li></ul>
+send_notify | object | Callback URL to notify when a message is sent. <ul><li>`url` - HTTP URL</li><li>`url_method` - HTTP URL method</li></ul>
+sms_enabled | string | FoneNumber is enabled for SMS service.
+mms_enabled | string | FoneNumber is enabled for MMS service.
+is_active | string | Status of FoneNumber. Potenial values are: <ul><li>`yes` - active</li><li>`no` - pending cancellation</li><li>`cancel` - cancelled</li></ul>.
+
 ## Update FoneNumber
 
 > Example Request
 
 ```shell
-# Set FoneNumber service type for `3212182662`
+# Set FoneNumber service type for `3215551111`
 # to receive messages to email address `support@domain.com`
 $ curl --request PUT
---url 'https://api.fonestorm.com/v2/fonenumbers/3212182662'
+--url 'https://api.fonestorm.com/v2/fonenumbers/3215551111'
 --header 'Content-Type: application/json'
 --header 'Accept: application/json'
 --header 'token: key'
@@ -352,11 +398,11 @@ $ curl --request PUT
 ```
 
 ```javascript
-// Set service for FoneNumber `3212182662`
+// Set service for FoneNumber `3215551111`
 // to receive messages to email address `support@domain.com`
 var FracTelApi211 = require('frac_tel_api_211');
 var apiInstance = new FracTelApi210.FonenumbersApi();
-var fonenumber = "3212182662"; // String | Your FracTEL FoneNumber.
+var fonenumber = "3215551111"; // String | Your FracTEL FoneNumber.
 var type = "Email";
 var opts = {
   'value': "support@domain.com",
@@ -374,12 +420,12 @@ apiInstance.putFonenumbersFonenumber(fonenumber, type, opts, callback);
 
 ```php
 <?php
-// Set service for FoneNumber `3212182662`
+// Set service for FoneNumber `3215551111`
 // to receive messages to email address `support@domain.com`
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new Swagger\Client\Api\FonenumbersApi();
-$fonenumber = "3212182662";
+$fonenumber = "3215551111";
 $type = "Email";
 $value = "support@domain.com";
 
@@ -393,7 +439,7 @@ try {
 ```
 
 ```python
-# Set service for FoneNumber `3212182662`
+# Set service for FoneNumber `3215551111`
 # to receive messages to email address `support@domain.com`
 from __future__ import print_function
 import time
@@ -403,7 +449,7 @@ from pprint import pprint
 
 # create an instance of the API class
 api_instance = swagger_client.FonenumbersApi()
-fonenumber = '3212182662'
+fonenumber = '3215551111'
 type = 'Email'
 value = 'support@domain.com'
 
@@ -442,12 +488,18 @@ fonenumber | string |  | A FoneNumber associated with the account.
 
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
-fonenumber | string |  | A FoneNumber associated with the account.
 type | string |  | Message routing type. Allowed values are `None`, `Device`, `Email`, `URL` or `Forward`.
 value | string |  | Message routing type value.
 url_method<br/>_optional_ | string |  | URL method. Allowed values are `GET`, `POST`, or `JSON`. See Notes for additional information.
 url_username<br/>_optional_ | string |  | URL username for HTTP **Basic** authentication scheme.
 url_password<br/>_optional_ | string |  | URL password for HTTP **Basic** authentication scheme.
+
+### Response Properties
+
+Property | Type | Description
+--------- | ------- | -----------
+status_code | integer | HTTP status code.
+result | string | Text result of the request.
 
 ### Notes
 
@@ -464,19 +516,19 @@ When `type` is `URL` then `url_method` is required. The URL `value` is expected 
 > Example Request
 
 ```shell
-# Cancel FoneNumber `3212182662` and remove from account.
+# Cancel FoneNumber `3215551111` and remove from account.
 $ curl --request DELETE
---url 'https://api.fonestorm.com/v2/fonenumbers/3212182662'
+--url 'https://api.fonestorm.com/v2/fonenumbers/3215551111'
 --header 'Content-Type: application/json'
 --header 'Accept: application/json'
 --header 'token: key'
 ```
 
 ```javascript
-// Cancel FoneNumber `3212182662` and remove from account.
+// Cancel FoneNumber `3215551111` and remove from account.
 var FracTelApi211 = require('frac_tel_api_211');
 var apiInstance = new FracTelApi210.FonenumbersApi();
-var fonenumber = "3212182662";
+var fonenumber = "3215551111";
 
 var callback = function(error, data, response) {
   if (error) {
@@ -490,11 +542,11 @@ apiInstance.deleteFonenumbersFonenumber(fonenumber, callback);
 
 ```php
 <?php
-// Cancel FoneNumber `3212182662` and remove from account.
+// Cancel FoneNumber `3215551111` and remove from account.
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new Swagger\Client\Api\FonenumbersApi();
-$fonenumber = "3212182662";
+$fonenumber = "3215551111";
 
 try {
     $result = $api_instance->deleteFonenumbersFonenumber($fonenumber);
@@ -506,7 +558,7 @@ try {
 ```
 
 ```python
-# Cancel FoneNumber `3212182662` and remove from account.
+# Cancel FoneNumber `3215551111` and remove from account.
 from __future__ import print_function
 import time
 import swagger_client
@@ -515,7 +567,7 @@ from pprint import pprint
 
 # create an instance of the API class
 api_instance = swagger_client.FonenumbersApi()
-fonenumber = '3212182662'
+fonenumber = '3215551111'
 
 try:
     # Remove FoneNumber from the account.
@@ -530,7 +582,7 @@ except ApiException as e:
 ```json
 {
   "status_code": 200,
-  "fonenumber": "3212335701",
+  "fonenumber": "3215551111",
   "result": "SUCCESS"
 }
 ```
@@ -548,3 +600,11 @@ Method | Route
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
 fonenumber | string |  | A FoneNumber associated with the account.
+
+### Response Properties
+
+Property | Type | Description
+--------- | ------- | -----------
+status_code | integer | HTTP status code.
+result | string | Text result of the request.
+fonenumber | string | FoneNumber that was deleted.

--- a/source/includes/_fonenumbers.md
+++ b/source/includes/_fonenumbers.md
@@ -14,7 +14,7 @@ $ curl --request GET
 ```
 
 ```javascript
-var FracTelApi211 = require('frac_tel_api_211');
+var FracTelApi212 = require('frac_tel_api_212');
 var apiInstance = new FracTelApi210.FonenumbersApi();
 var opts = {
   'filter': "all"
@@ -83,7 +83,7 @@ except ApiException as e:
           "url_method": "JSON"
         },
         "receive_notify": {
-          "url": "https://hookbin.com/bin/KNRzy7P3",
+          "url": "https://hookb.in/KNRzy7P3",
           "method": "JSON"
         },
         "send_notify": {
@@ -101,7 +101,7 @@ except ApiException as e:
 }
 ```
 
-Get all active FoneNumbers listed under the account.
+Get all the active FoneNumbers listed under the account.
 
 ### HTTP Request
 
@@ -113,7 +113,7 @@ Method | Route
 
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
-filter | string | fonenumbers | Filter the response attributes. Allowed values are `fonenumbers` or `all`. See Notes for additional information.
+filter | string | fonenumbers | Filter the response attributes. Allowed values are `fonenumbers` or `all`. See **Notes** for additional information.
 
 ### Response Properties
 
@@ -128,9 +128,9 @@ sms_options | object | SMS related properties.
 receive | object | Delivery service type used as the destination to receive messages. <ul><li>`type` - configured service type</li><li>`email` - email address if configured for email</li><li>`device` - FracTEL device if configured for device</li><li>`forward` - telephone number if configured for forward</li><li>`url` - HTTP URL if configured for URL</li><li>`url_method` - HTTP URL method if configured for URL</li></ul>
 receive_notify | object | Callback URL to notify when a message is received. <ul><li>`url` - HTTP URL</li><li>`url_method` - HTTP URL method</li></ul>
 send_notify | object | Callback URL to notify when a message is sent. <ul><li>`url` - HTTP URL</li><li>`url_method` - HTTP URL method</li></ul>
-sms_enabled | string | FoneNumber is enabled for SMS service.
-mms_enabled | string | FoneNumber is enabled for MMS service.
-is_active | string | Status of FoneNumber. Potenial values are: <ul><li>`yes` - active</li><li>`no` - pending cancellation</li><li>`cancel` - cancelled</li></ul>.
+sms_enabled | string | SMS service is enabled for FoneNumber.
+mms_enabled | string | MMS service is enabled for FoneNumber.
+is_active | string | Status of FoneNumber. Potenial values are: <ul><li>`yes` - active</li><li>`no` - pending cancelation</li><li>`cancel` - canceled</li></ul>.
 
 ### Notes
 
@@ -146,7 +146,7 @@ The default `filter` value is `fonenumbers`. For a more detailed response you ma
 > Example Request
 
 ```shell
-# Order quick FoneNumber with a `321` area code.
+# Order quick FoneNumber with a '321' area code.
 $ curl --request POST
 --url 'https://api.fonestorm.com/v2/fonenumbers'
 --header 'Content-Type: application/json'
@@ -156,8 +156,8 @@ $ curl --request POST
 ```
 
 ```javascript
-// Order FoneNumber with a `321` area code.
-var FracTelApi211 = require('frac_tel_api_211');
+// Order FoneNumber with a '321' area code.
+var FracTelApi212 = require('frac_tel_api_212');
 var apiInstance = new FracTelApi210.FonenumbersApi();
 var areaCode = "321";
 
@@ -173,7 +173,7 @@ apiInstance.postFonenumbers(areaCode, callback);
 
 ```php
 <?php
-// Order FoneNumber with a `321` area code.
+// Order FoneNumber with a '321' area code.
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new Swagger\Client\Api\FonenumbersApi();
@@ -189,7 +189,7 @@ try {
 ```
 
 ```python
-# Order FoneNumber with a `321` area code.
+# Order FoneNumber with a '321' area code.
 from __future__ import print_function
 import time
 import swagger_client
@@ -249,8 +249,8 @@ Property | Type | Description
 status_code | integer | HTTP status code.
 result | string | Text result of the request.
 fonenumber | string | FoneNumber.
-sms_enabled | string | FoneNumber is enabled for SMS service.
-mms_enabled | string | FoneNumber is enabled for MMS service.
+sms_enabled | string | SMS service is enabled for FoneNumber.
+mms_enabled | string | MMS service is enabled for FoneNumber.
 state | string | State FoneNumber is registered.
 rate_center | string | Rate center for the FoneNumber.
 
@@ -259,7 +259,7 @@ rate_center | string | Rate center for the FoneNumber.
 > Example Request
 
 ```shell
-# Get details for FoneNumber `3215551111`
+# Get details for FoneNumber '3215551111'
 $ curl --request GET
 --url 'https://api.fonestorm.com/v2/fonenumbers/3215551111'
 --header 'Content-Type: application/json'
@@ -268,8 +268,8 @@ $ curl --request GET
 ```
 
 ```javascript
-// Get details for FoneNumber `3215551111`
-var FracTelApi211 = require('frac_tel_api_211');
+// Get details for FoneNumber '3215551111'
+var FracTelApi212 = require('frac_tel_api_212');
 var apiInstance = new FracTelApi210.FonenumbersApi();
 var fonenumber = "3215551111";
 
@@ -285,7 +285,7 @@ apiInstance.getFonenumbersFonenumber(fonenumber, callback);
 
 ```php
 <?php
-// Get details for FoneNumber `3215551111`
+// Get details for FoneNumber '3215551111'
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new Swagger\Client\Api\FonenumbersApi();
@@ -301,7 +301,7 @@ try {
 ```
 
 ```python
-# Get details for FoneNumber `3215551111`
+# Get details for FoneNumber '3215551111'
 from __future__ import print_function
 import time
 import swagger_client
@@ -310,7 +310,7 @@ from pprint import pprint
 
 # create an instance of the API class
 api_instance = swagger_client.FonenumbersApi()
-fonenumber = '3215551111' # str | Your FracTEL fonenumber.
+fonenumber = '3215551111'
 
 try:
     # Get a single FoneNumber listed under the account.
@@ -337,7 +337,7 @@ except ApiException as e:
         "url_method": "JSON"
       },
       "receive_notify": {
-        "url": "https://hookbin.com/bin/KNRzy7P3",
+        "url": "https://hookb.in/KNRzy7P3",
         "method": "JSON"
       },
       "send_notify": {
@@ -378,17 +378,17 @@ sms_options | object | SMS related properties.
 receive | object | Delivery service type used as the destination to receive messages. <ul><li>`type` - configured service type</li><li>`email` - email address if configured for email</li><li>`device` - FracTEL device if configured for device</li><li>`forward` - telephone number if configured for forward</li><li>`url` - HTTP URL if configured for URL</li><li>`url_method` - HTTP URL method if configured for URL</li></ul>
 receive_notify | object | Callback URL to notify when a message is received. <ul><li>`url` - HTTP URL</li><li>`url_method` - HTTP URL method</li></ul>
 send_notify | object | Callback URL to notify when a message is sent. <ul><li>`url` - HTTP URL</li><li>`url_method` - HTTP URL method</li></ul>
-sms_enabled | string | FoneNumber is enabled for SMS service.
-mms_enabled | string | FoneNumber is enabled for MMS service.
-is_active | string | Status of FoneNumber. Potenial values are: <ul><li>`yes` - active</li><li>`no` - pending cancellation</li><li>`cancel` - cancelled</li></ul>.
+sms_enabled | string | SMS service is enabled for FoneNumber.
+mms_enabled | string | MMS service is enabled for FoneNumber.
+is_active | string | Status of FoneNumber. Potenial values are: <ul><li>`yes` - active</li><li>`no` - pending cancelation</li><li>`cancel` - canceled</li></ul>.
 
 ## Update FoneNumber
 
 > Example Request
 
 ```shell
-# Set FoneNumber service type for `3215551111`
-# to receive messages to email address `support@domain.com`
+# Set FoneNumber service type for '3215551111'
+# to receive messages to email address 'support@domain.com'
 $ curl --request PUT
 --url 'https://api.fonestorm.com/v2/fonenumbers/3215551111'
 --header 'Content-Type: application/json'
@@ -398,11 +398,11 @@ $ curl --request PUT
 ```
 
 ```javascript
-// Set service for FoneNumber `3215551111`
-// to receive messages to email address `support@domain.com`
-var FracTelApi211 = require('frac_tel_api_211');
+// Set service for FoneNumber '3215551111'
+// to receive messages to email address 'support@domain.com'
+var FracTelApi212 = require('frac_tel_api_212');
 var apiInstance = new FracTelApi210.FonenumbersApi();
-var fonenumber = "3215551111"; // String | Your FracTEL FoneNumber.
+var fonenumber = "3215551111";
 var type = "Email";
 var opts = {
   'value': "support@domain.com",
@@ -420,8 +420,8 @@ apiInstance.putFonenumbersFonenumber(fonenumber, type, opts, callback);
 
 ```php
 <?php
-// Set service for FoneNumber `3215551111`
-// to receive messages to email address `support@domain.com`
+// Set service for FoneNumber '3215551111'
+// to receive messages to email address 'support@domain.com'
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new Swagger\Client\Api\FonenumbersApi();
@@ -439,8 +439,8 @@ try {
 ```
 
 ```python
-# Set service for FoneNumber `3215551111`
-# to receive messages to email address `support@domain.com`
+# Set service for FoneNumber '3215551111'
+# to receive messages to email address 'support@domain.com'
 from __future__ import print_function
 import time
 import swagger_client
@@ -488,7 +488,7 @@ fonenumber | string |  | A FoneNumber associated with the account.
 
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
-type | string |  | Message routing type. Allowed values are `None`, `Device`, `Email`, `URL` or `Forward`.
+type | string |  | Message routing type. Allowed values are `None`, `Device`, `Email`, `URL`, or `Forward`.
 value | string |  | Message routing type value.
 url_method<br/>_optional_ | string |  | URL method. Allowed values are `GET`, `POST`, or `JSON`. See Notes for additional information.
 url_username<br/>_optional_ | string |  | URL username for HTTP **Basic** authentication scheme.
@@ -516,7 +516,7 @@ When `type` is `URL` then `url_method` is required. The URL `value` is expected 
 > Example Request
 
 ```shell
-# Cancel FoneNumber `3215551111` and remove from account.
+# Cancel FoneNumber '3215551111' and remove from account.
 $ curl --request DELETE
 --url 'https://api.fonestorm.com/v2/fonenumbers/3215551111'
 --header 'Content-Type: application/json'
@@ -525,8 +525,8 @@ $ curl --request DELETE
 ```
 
 ```javascript
-// Cancel FoneNumber `3215551111` and remove from account.
-var FracTelApi211 = require('frac_tel_api_211');
+// Cancel FoneNumber '3215551111' and remove from account.
+var FracTelApi212 = require('frac_tel_api_212');
 var apiInstance = new FracTelApi210.FonenumbersApi();
 var fonenumber = "3215551111";
 
@@ -542,7 +542,7 @@ apiInstance.deleteFonenumbersFonenumber(fonenumber, callback);
 
 ```php
 <?php
-// Cancel FoneNumber `3215551111` and remove from account.
+// Cancel FoneNumber '3215551111' and remove from account.
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new Swagger\Client\Api\FonenumbersApi();
@@ -558,7 +558,7 @@ try {
 ```
 
 ```python
-# Cancel FoneNumber `3215551111` and remove from account.
+# Cancel FoneNumber '3215551111' and remove from account.
 from __future__ import print_function
 import time
 import swagger_client

--- a/source/includes/_fonenumbers.md
+++ b/source/includes/_fonenumbers.md
@@ -14,8 +14,8 @@ $ curl --request GET
 ```
 
 ```javascript
-var FracTelApi212 = require('frac_tel_api_212');
-var apiInstance = new FracTelApi210.FonenumbersApi();
+var FracTelApi = require('frac_tel_api_212');
+var apiInstance = new FracTelApi.FonenumbersApi();
 var opts = {
   'filter': "all"
 };
@@ -157,8 +157,8 @@ $ curl --request POST
 
 ```javascript
 // Order FoneNumber with a '321' area code.
-var FracTelApi212 = require('frac_tel_api_212');
-var apiInstance = new FracTelApi210.FonenumbersApi();
+var FracTelApi = require('frac_tel_api_212');
+var apiInstance = new FracTelApi.FonenumbersApi();
 var areaCode = "321";
 
 var callback = function(error, data, response) {
@@ -269,8 +269,8 @@ $ curl --request GET
 
 ```javascript
 // Get details for FoneNumber '3215551111'
-var FracTelApi212 = require('frac_tel_api_212');
-var apiInstance = new FracTelApi210.FonenumbersApi();
+var FracTelApi = require('frac_tel_api_212');
+var apiInstance = new FracTelApi.FonenumbersApi();
 var fonenumber = "3215551111";
 
 var callback = function(error, data, response) {
@@ -400,8 +400,8 @@ $ curl --request PUT
 ```javascript
 // Set service for FoneNumber '3215551111'
 // to receive messages to email address 'support@domain.com'
-var FracTelApi212 = require('frac_tel_api_212');
-var apiInstance = new FracTelApi210.FonenumbersApi();
+var FracTelApi = require('frac_tel_api_212');
+var apiInstance = new FracTelApi.FonenumbersApi();
 var fonenumber = "3215551111";
 var type = "Email";
 var opts = {
@@ -526,8 +526,8 @@ $ curl --request DELETE
 
 ```javascript
 // Cancel FoneNumber '3215551111' and remove from account.
-var FracTelApi212 = require('frac_tel_api_212');
-var apiInstance = new FracTelApi210.FonenumbersApi();
+var FracTelApi = require('frac_tel_api_212');
+var apiInstance = new FracTelApi.FonenumbersApi();
 var fonenumber = "3215551111";
 
 var callback = function(error, data, response) {

--- a/source/includes/_fonenumbers.md
+++ b/source/includes/_fonenumbers.md
@@ -125,7 +125,7 @@ total | integer | Total number of account FoneNumbers listed.
 fonenumbers | array | Array of account FoneNumbers.
 fonenumber | string | FoneNumber.
 sms_options | object | SMS related properties.
-receive | object | Delivery service type used as the destination to receive messages. <ul><li>`type` - service type</li><li>`email` - email address if configured for email</li><li>`device` - FracTEL device if configured for device</li><li>`forward` - telephone number if configured for forward</li><li>`url` - HTTP URL if configured for URL</li><li>`url_method` - HTTP URL method if configured for URL</li></ul>
+receive | object | Delivery service type used as the destination to receive messages. <ul><li>`type` - configured service type</li><li>`email` - email address if configured for email</li><li>`device` - FracTEL device if configured for device</li><li>`forward` - telephone number if configured for forward</li><li>`url` - HTTP URL if configured for URL</li><li>`url_method` - HTTP URL method if configured for URL</li></ul>
 receive_notify | object | Callback URL to notify when a message is received. <ul><li>`url` - HTTP URL</li><li>`url_method` - HTTP URL method</li></ul>
 send_notify | object | Callback URL to notify when a message is sent. <ul><li>`url` - HTTP URL</li><li>`url_method` - HTTP URL method</li></ul>
 sms_enabled | string | FoneNumber is enabled for SMS service.
@@ -375,7 +375,7 @@ status_code | integer | HTTP status code.
 result | string | Text result of the request.
 fonenumber | string | FoneNumber.
 sms_options | object | SMS related properties.
-receive | object | Delivery service type used as the destination to receive messages. <ul><li>`type` - service type</li><li>`email` - email address if configured for email</li><li>`device` - FracTEL device if configured for device</li><li>`forward` - telephone number if configured for forward</li><li>`url` - HTTP URL if configured for URL</li><li>`url_method` - HTTP URL method if configured for URL</li></ul>
+receive | object | Delivery service type used as the destination to receive messages. <ul><li>`type` - configured service type</li><li>`email` - email address if configured for email</li><li>`device` - FracTEL device if configured for device</li><li>`forward` - telephone number if configured for forward</li><li>`url` - HTTP URL if configured for URL</li><li>`url_method` - HTTP URL method if configured for URL</li></ul>
 receive_notify | object | Callback URL to notify when a message is received. <ul><li>`url` - HTTP URL</li><li>`url_method` - HTTP URL method</li></ul>
 send_notify | object | Callback URL to notify when a message is sent. <ul><li>`url` - HTTP URL</li><li>`url_method` - HTTP URL method</li></ul>
 sms_enabled | string | FoneNumber is enabled for SMS service.

--- a/source/includes/_introduction.md
+++ b/source/includes/_introduction.md
@@ -8,7 +8,7 @@ The FoneStorm API is organized around [REST](http://en.wikipedia.org/wiki/Repres
 
 ## Using FoneStorm
 
-You will need an active FracTEL account with API access enabled to use the FoneStorm API. Call us at (321) 499-1000 or email [sales@fonestorm.com](mailto:sales@fonestorm.com?subject=FracTEL%20API%20Access%20Request) to get set up.
+You will need an active FracTEL account with API access enabled to use the FoneStorm API. Call us at (321) 499-1000 or email [sales@fonestorm.com](mailto:sales@fonestorm.com?subject=FoneStorm%20API%20Access%20Request) to get set up.
 
 All operations are scoped to the FracTEL account being used to authenticate. Whenever this documentation makes reference to "the account" or "your account", it is referring to the account that was used to obtain the API key.
 
@@ -20,7 +20,7 @@ All URLs referenced in the documentation have the following base:
 
 ## FoneNumbers
 
-A FoneNumber&trade; is an all-purpose communication service routing handle provided by FracTEL. A FoneNumber is an actual telephone number and it can be called or messaged from any landline or mobile telephone. It can be configured to route voice calls, faxes and SMS/MMS messages to another telephone, however a FoneNumber is capable of much more -- and this power is exposed  through the FoneStorm API platform.
+A FoneNumber&trade; is an all-purpose communication service routing handle provided by FracTEL. A FoneNumber is an actual telephone number and it can be called or messaged from any landline or mobile telephone. It can be configured to route voice calls, faxes and SMS/MMS messages to another telephone. However, a FoneNumber is capable of much more -- and this power is exposed  through the FoneStorm API platform.
 
 ## Dates and Times
 
@@ -48,7 +48,7 @@ FoneStorm clients are available in a variety of languages and environments at th
 
 These clients are auto-generated with [swagger-codegen](https://github.com/swagger-api/swagger-codegen).
 
-Code examples throughout this documentation, with the exception of cURL examples, is based on the use of these clients.
+Code examples throughout this documentation, with the exception of cURL examples, are based on the use of these clients.
 
 ## Terms and Conditions
 

--- a/source/includes/_messages.md
+++ b/source/includes/_messages.md
@@ -7,8 +7,8 @@
 ```shell
 # Send an MMS message "Hello World"
 # that does not require confirmation
-# from FracTEL phone number 3211234566
-# to a recipent 3211234567
+# from FoneNumber 3215551111
+# to a recipent 3215552222
 # containing an image https://www.fractel.net/wp-content/uploads/2014/03/FracTEL_Tag_Logo.png
 # with a callback url https://hookb.in/vDkMOVB9
 $ curl --request POST
@@ -16,20 +16,20 @@ $ curl --request POST
 --header 'Content-Type: application/json'
 --header 'Accept: application/json'
 --header 'token: key'
---data '{"to":"3211234567", "from": "3211234566", "message": "Hello%20World", "media_url": "https://www.fractel.net/wp-content/uploads/2014/03/FracTEL_Tag_Logo.png", "confirmation_url": "https%3A%2F%2Fhookb.in%2FvDkMOVB9", "require_confirmation": false}'
+--data '{"to":"3215552222", "fonenumber": "3215551111", "message": "Hello%20World", "media_url": "https://www.fractel.net/wp-content/uploads/2014/03/FracTEL_Tag_Logo.png", "confirmation_url": "https%3A%2F%2Fhookb.in%2FvDkMOVB9", "require_confirmation": false}'
 ```
 
 ```javascript
 // Send an MMS message "Hello World"
 // that does not require confirmation
-// from FracTEL phone number 3211234566
-// to a recipent 3211234567
+// from FoneNumber 3215551111
+// to a recipent 3215552222
 // containing an image https://www.fractel.net/wp-content/uploads/2014/03/FracTEL_Tag_Logo.png
 // with a callback url https://hookb.in/vDkMOVB9
 var FracTelApi211 = require('frac_tel_api_211');
 var apiInstance = new FracTelApi211.MessagesApi();
-var to = "3211234567";
-var fonenumber = "3211234566";
+var to = "3215552222";
+var fonenumber = "3215551111";
 var message = "Hello World";
 var opts = {
   'mediaUrl': ["https://www.fractel.net/wp-content/uploads/2014/03/FracTEL_Tag_Logo.png"],
@@ -51,15 +51,15 @@ apiInstance.postMessagesSend(to, fonenumber, message, opts, callback);
 <?php
 // Send an MMS message "Hello World"
 // that does not require confirmation
-// from FracTEL phone number 3211234566
-// to a recipent 3211234567
+// from FoneNumber 3215551111
+// to a recipent 3215552222
 // containing an image https://www.fractel.net/wp-content/uploads/2014/03/FracTEL_Tag_Logo.png
 // with a callback url https://hookb.in/vDkMOVB9
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new Swagger\Client\Api\MessagesApi();
-$to = "3211234567";
-$fonenumber = "3211234566";
+$to = "3215552222";
+$fonenumber = "3215551111";
 $message = "Hello World";
 $media_url = array("https://www.fractel.net/wp-content/uploads/2014/03/FracTEL_Tag_Logo.png");
 $confirmation_url = "https://hookb.in/vDkMOVB9";
@@ -79,8 +79,8 @@ try {
 ```python
 # Send an MMS message "Hello World"
 # that does not require confirmation
-# from FracTEL phone number 3211234566
-# to a recipent 3211234567
+# from FoneNumber 3215551111
+# to a recipent 3215552222
 # containing an image https://www.fractel.net/wp-content/uploads/2014/03/FracTEL_Tag_Logo.png
 # with a callback url https://hookb.in/vDkMOVB9
 from __future__ import print_function
@@ -91,8 +91,8 @@ from pprint import pprint
 
 # create an instance of the API class
 api_instance = swagger_client.MessagesApi()
-to = '3211234567'
-fonenumber = '3211234566'
+to = '3215552222'
+fonenumber = '3215551111'
 message = 'Hello World'
 media_url = ['https://www.fractel.net/wp-content/uploads/2014/03/FracTEL_Tag_Logo.png']
 confirmation_url = 'https://hookb.in/vDkMOVB9'
@@ -129,11 +129,19 @@ Method | Route
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
 to | string |  | The recipient's 10 digit phone number.
-from | string | | Your 10 digit fonenumber.
+fonenumber | string | | A FoneNumber associated with the account.
 message | string | | Contents of the SMS or MMS.
 media_url<br/>_optional_ | array[string] | | Valid HTTP or HTTPS URL(s) for media to send via MMS. See **Notes** for additional information.
 confirmation_url<br/>_optional_ | string | | Valid HTTP or HTTPS URL that will accept callback data after the message is sent. See **Notes** for additional information.
 require_confirmation<br/>_optional_ | string | | Only send message if confirmation is available. See **Notes** for additional information.
+
+### Response Properties
+
+Property | Type | Description
+--------- | ------- | -----------
+status_code | integer | HTTP status code.
+result | string | Text result of the request.
+uid | string | Unique identifier of the sent message.
 
 <aside class="notice">
 Networks impose a limit of one message per second per sending (`from`) number. Calls that exceed this rate limit will receive an error code of `400 - Rate Limit Exceeded`.
@@ -199,7 +207,7 @@ Sending messages may result in additional charges and fees to your account.
 > Example Request
 
 ```shell
-# Configure FracTEL phone number 3211234567 to receive a callback with
+# Configure FoneNumber 3215551111 to receive a callback with
 # POST data (application/x-www-form-urlencoded) to url https://hookb.in/vDkMOVB9
 # when a message is sent.
 curl --request POST
@@ -207,16 +215,16 @@ curl --request POST
 --header 'Content-Type: application/json'
 --header 'Accept: application/json'
 --header 'token: key'
---data '{"from":"3211234567", "method":"POST", "url": "https%3A%2F%2Fhookb.in%2FvDkMOVB9" }'
+--data '{"fonenumber":"3215551111", "method":"POST", "url": "https%3A%2F%2Fhookb.in%2FvDkMOVB9" }'
 ```
 
 ```javascript
-// Configure FoneNumber 3211234567 to receive a callback with
+// Configure FoneNumber 3215551111 to receive a callback with
 // POST data (application/x-www-form-urlencoded) to url https://hookb.in/vDkMOVB9
 // when a message is sent.
 var FracTelApi211 = require('frac_tel_api_211');
 var apiInstance = new FracTelApi211.MessagesApi();
-var fonenumber = "3211234567";
+var fonenumber = "3215551111";
 var method = "POST";
 var url = "https://hookb.in/vDkMOVB9";
 var opts = {};
@@ -233,13 +241,13 @@ apiInstance.postMessagesSendNotify(fonenumber, method, url, opts, callback);
 
 ```php
 <?php
-// Configure FoneNumber 3211234567 to receive a callback with
+// Configure FoneNumber 3215551111 to receive a callback with
 // POST data (application/x-www-form-urlencoded) to url https://hookb.in/vDkMOVB9
 // when a message is sent.
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new Swagger\Client\Api\MessagesApi();
-$fonenumber = "3211234567";
+$fonenumber = "3215551111";
 $method = "POST";
 $url = "https://hookb.in/vDkMOVB9";
 
@@ -253,7 +261,7 @@ try {
 ```
 
 ```python
-# Configure FoneNumber 3211234567 to receive a callback with
+# Configure FoneNumber 3215551111 to receive a callback with
 # POST data (application/x-www-form-urlencoded) to url https://hookb.in/vDkMOVB9
 # when a message is sent.
 from __future__ import print_function
@@ -264,7 +272,7 @@ from pprint import pprint
 
 # create an instance of the API class
 api_instance = swagger_client.MessagesApi()
-fonenumber = '3211234567'
+fonenumber = '3215551111'
 method = 'POST'
 url = 'https://hookb.in/vDkMOVB9'
 
@@ -285,7 +293,7 @@ except ApiException as e:
 }
 ```
 
-Configure the callback URL to notify when a message is sent. Each FracTEL phone number can be configured to use its own callback URL for handling send notifications.
+Configure the callback URL to notify when a message is sent. Each FoneNumber can be configured to use its own callback URL for handling send notifications.
 
 ### HTTP Request
 
@@ -297,9 +305,16 @@ Method | Route
 
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
-from | string |  | A FoneNumber associated with the account.
+fonenumber | string |  | A FoneNumber associated with the account.
 url | string | | Callback URL. See **Notes** for additional information.
 method | string | | Allowed values are `GET`,`POST`, or `JSON`. See **Notes** for additional information.
+
+### Response Properties
+
+Property | Type | Description
+--------- | ------- | -----------
+status_code | integer | HTTP status code.
+result | string | Text result of the request.
 
 ### Notes
 
@@ -331,22 +346,22 @@ Callback URLs using the `GET` method use token replacements to place callback da
 > Example Request
 
 ```shell
-# Deliver all messages received by FracTEL phone number 3211234567
+# Deliver all messages received by FoneNumber 3215551111
 # to an email address email@domain.
 $ curl --request POST
 --url 'https://api.fonestorm.com/v2/messages/receive'
 --header 'Content-Type: application/json'
 --header 'Accept: application/json'
 --header 'token: key'
---data '{"to": "3211234567", "type": "Email", "value": "email@domain.com"}'
+--data '{"fonenumber": "3215551111", "type": "Email", "value": "email@domain.com"}'
 ```
 
 ```javascript
-// Deliver all messages received by FoneNumber 3211234567
+// Deliver all messages received by FoneNumber 3215551111
 // to an email address email@domain.
 var FracTelApi211 = require('frac_tel_api_211');
 var apiInstance = new FracTelApi211.MessagesApi();
-var fonenumber = "3211234567";
+var fonenumber = "3215551111";
 var type = "Email";
 var opts = {
   'value': "email@domain.com"
@@ -364,12 +379,12 @@ apiInstance.postMessagesReceive(fonenumber, type, opts, callback);
 
 ```php
 <?php
-// Deliver all messages received by FoneNumber 3211234567
+// Deliver all messages received by FoneNumber 3215551111
 // to an email address email@domain.
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new Swagger\Client\Api\MessagesApi();
-$fonenumber = "3211234567";
+$fonenumber = "3215551111";
 $type = "Email";
 $value = "email@domain.com";
 
@@ -383,7 +398,7 @@ try {
 ```
 
 ```python
-# Deliver all messages received by FoneNumber 3211234567
+# Deliver all messages received by FoneNumber 3215551111
 # to an email address email@domain.
 from __future__ import print_function
 import time
@@ -393,7 +408,7 @@ from pprint import pprint
 
 # create an instance of the API class
 api_instance = swagger_client.MessagesApi()
-fonenumber = '3211234567'
+fonenumber = '3215551111'
 type = 'Email'
 value = 'email@domain.com'
 
@@ -426,9 +441,16 @@ Method | Route
 
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
-to | string |  | A FoneNumber associated with the account.
+fonenumber | string |  | A FoneNumber associated with the account.
 type | string | | Message service routing type. Allowed values are `Device`, `Email`, `URL`, `Forward`, or `None`. See **Notes** for additional information.
 value | string | | Value of the chosen message routing type. Allows for a _Device ID_, _Email Address_, _URL_ or _Phone Number_ depending on the specified `type`. See **Notes** for additional information.
+
+### Response Properties
+
+Property | Type | Description
+--------- | ------- | -----------
+status_code | integer | HTTP status code.
+result | string | Text result of the request.
 
 ### Notes
 
@@ -445,7 +467,7 @@ Type | Value | Example
 Device | The ID for the destination device | 987123543678
 Email  | An email address                  | bingo@stokes.com
 URL    | A callback URL                    | https://api.yourserver.com/handler.php?msg={{msg}}
-Forward | A forwarding phone number        | 3211234567
+Forward | A forwarding phone number        | 3215551111
 None    | _None_                           |
 
 #### Callback Data
@@ -464,7 +486,7 @@ Callback URLs use the `POST` method and use token replacements to place callback
 > Example Request
 
 ```shell
-# Configure FracTEL phone number 3211234567 to receive a callback with
+# Configure FoneNumber 3215551111 to receive a callback with
 # JSON payload data (application/json) to url https://hookb.in/vDkMOVB9
 # when a message is received.
 $ curl --request POST
@@ -472,16 +494,16 @@ $ curl --request POST
 --header 'Content-Type: application/json'
 --header 'Accept: application/json'
 --header 'token: key'
---data '{"to": "3211234567", "method": "JSON", "url": "https%3A%2F%2Fhookb.in%2FvDkMOVB9"}'
+--data '{"fonenumber": "3215551111", "method": "JSON", "url": "https%3A%2F%2Fhookb.in%2FvDkMOVB9"}'
 ```
 
 ```javascript
-// Configure FoneNumber 3211234567 to receive a callback with
+// Configure FoneNumber 3215551111 to receive a callback with
 // JSON payload data (application/json) to url https://hookb.in/vDkMOVB9
 // when a message is received.
 var FracTelApi211 = require('frac_tel_api_211');
 var apiInstance = new FracTelApi211.MessagesApi();
-var fonenumber = "3211234567";
+var fonenumber = "3215551111";
 var method = "JSON";
 var url = "https://hookb.in/vDkMOVB9";
 var opts = {};
@@ -498,13 +520,13 @@ apiInstance.postMessagesReceiveNotify(fonenumber, method, url, opts, callback);
 
 ```php
 <?php
-// Configure FoneNumber 3211234567 to receive a callback with
+// Configure FoneNumber 3215551111 to receive a callback with
 // JSON payload data (application/json) to url https://hookb.in/vDkMOVB9
 // when a message is received.
 require_once(__DIR__ . '/vendor/autoload.php');
 
 $api_instance = new Swagger\Client\Api\MessagesApi();
-$fonenumber = "3211234567";
+$fonenumber = "3215551111";
 $method = "JSON";
 $url = "https://hookb.in/vDkMOVB9";
 
@@ -518,7 +540,7 @@ try {
 ```
 
 ```python
-# Configure FoneNumber 3211234567 to receive a callback with
+# Configure FoneNumber 3215551111 to receive a callback with
 # JSON payload data (application/json) to url https://hookb.in/vDkMOVB9
 # when a message is received.
 from __future__ import print_function
@@ -529,7 +551,7 @@ from pprint import pprint
 
 # create an instance of the API class
 api_instance = swagger_client.MessagesApi()
-fonenumber = '3211234567'
+fonenumber = '3215551111'
 method = 'JSON'
 url = 'https://hookb.in/vDkMOVB9'
 
@@ -562,15 +584,22 @@ Method | Route
 
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
-to | string |  | A FoneNumber associated with the account.
+fonenumber | string |  | A FoneNumber associated with the account.
 url | string | | Callback URL. See **Notes** for additional information.
 method | string | | Allowed values are `GET`,`POST`, or `JSON`. See **Notes** for additional information.
+
+### Response Properties
+
+Property | Type | Description
+--------- | ------- | -----------
+status_code | integer | HTTP status code.
+result | string | Text result of the request.
 
 ### Notes
 
 #### `url`
 
-This is a valid HTTP or HTTPS URL that will accept callback data when a message is sent to the FracTEL phone number specified in `from`.
+This is a valid HTTP or HTTPS URL that will accept callback data when a message is sent to the FoneNumber specified in `fonenumber`.
 
 #### `method`
 

--- a/source/includes/_messages.md
+++ b/source/includes/_messages.md
@@ -26,8 +26,8 @@ $ curl --request POST
 // to a recipent 3215552222
 // containing an image https://www.fractel.net/wp-content/uploads/2014/03/FracTEL_Tag_Logo.png
 // with a callback url https://hookb.in/vDkMOVB9
-var FracTelApi211 = require('frac_tel_api_211');
-var apiInstance = new FracTelApi211.MessagesApi();
+var FracTelApi212 = require('frac_tel_api_212');
+var apiInstance = new FracTelApi212.MessagesApi();
 var to = "3215552222";
 var fonenumber = "3215551111";
 var message = "Hello World";
@@ -144,7 +144,7 @@ result | string | Text result of the request.
 uid | string | Unique identifier of the sent message.
 
 <aside class="notice">
-Networks impose a limit of one message per second per sending (`from`) number. Calls that exceed this rate limit will receive an error code of `400 - Rate Limit Exceeded`.
+Networks impose a limit of one message per second per sending (<code>from</code>) number. Calls that exceed this rate limit will receive an error code of <code>400 - Rate Limit Exceeded</code>.
 </aside>
 
 ### Notes
@@ -178,11 +178,9 @@ Extension | File Type | - | Extension | File Type | - | Extension | File Type | 
 .3ga | audio/amr | | .gif | image/gif | | .wap | text/vnd.wap.wml | | .wmv | video/x-ms-wmv
 .amr | audio/amr | | .jpeg | image/jpeg | | .xml | text/xml
 
-Up to ten URLs can be accepted per message.
-
 #### `confirmation_url`
 
-Message sending confirmation callback URLs receive JSON data via a <code>POST</code> request (see below for a description of the data package) but can also use token replacements to receive callback data values in query string parameters. For example, the following partial query string maps each callback data value to parameters in the query string: <code>recipient={{to}}&sender={{from}}&message={{msg}}&code={{dc}}&state={{ds}}</code>
+Message sending confirmation callback URLs receive JSON data via a `POST` request (see below for a description of the data package) but can also use token replacements to receive callback data values in query string parameters. For example, the following partial query string maps each callback data value to parameters in the query string: `recipient={{to}}&sender={{from}}&message={{msg}}&code={{dc}}&state={{ds}}`
 
 Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
@@ -222,8 +220,8 @@ curl --request POST
 // Configure FoneNumber 3215551111 to receive a callback with
 // POST data (application/x-www-form-urlencoded) to url https://hookb.in/vDkMOVB9
 // when a message is sent.
-var FracTelApi211 = require('frac_tel_api_211');
-var apiInstance = new FracTelApi211.MessagesApi();
+var FracTelApi212 = require('frac_tel_api_212');
+var apiInstance = new FracTelApi212.MessagesApi();
 var fonenumber = "3215551111";
 var method = "POST";
 var url = "https://hookb.in/vDkMOVB9";
@@ -339,7 +337,7 @@ from | string | | FoneNumber of sender.
 message | string | | Contents of the message.
 uid | string | | Unique identifier for the message.
 
-Callback URLs using the `GET` method use token replacements to place callback data values in query string parameters. For example, the following partial query string maps each callback data value to parameters in the query string: <code>recipient={{to}}&sender={{from}}&message={{msg}}&id={{uid}}</code>
+Callback URLs using the `GET` method use token replacements to place callback data values in query string parameters. For example, the following partial query string maps each callback data value to parameters in the query string: `recipient={{to}}&sender={{from}}&message={{msg}}&id={{uid}}`
 
 ## Receive
 
@@ -359,8 +357,8 @@ $ curl --request POST
 ```javascript
 // Deliver all messages received by FoneNumber 3215551111
 // to an email address email@domain.
-var FracTelApi211 = require('frac_tel_api_211');
-var apiInstance = new FracTelApi211.MessagesApi();
+var FracTelApi212 = require('frac_tel_api_212');
+var apiInstance = new FracTelApi212.MessagesApi();
 var fonenumber = "3215551111";
 var type = "Email";
 var opts = {
@@ -443,7 +441,7 @@ Parameter | Type | Default | Description
 --------- | ------- | ----------- | -----------
 fonenumber | string |  | A FoneNumber associated with the account.
 type | string | | Message service routing type. Allowed values are `Device`, `Email`, `URL`, `Forward`, or `None`. See **Notes** for additional information.
-value | string | | Value of the chosen message routing type. Allows for a _Device ID_, _Email Address_, _URL_ or _Phone Number_ depending on the specified `type`. See **Notes** for additional information.
+value | string | | Value of the chosen message routing type. Allows for a _Device ID_, _Email Address_, _URL_, or _Phone Number_ depending on the specified `type`. See **Notes** for additional information.
 
 ### Response Properties
 
@@ -479,7 +477,7 @@ from | string | | Phone number of sender.
 message | string | | Contents of the message.
 uid | string | | Unique identifier for the message.
 
-Callback URLs use the `POST` method and use token replacements to place callback data values in query string parameters. For example, the following partial query string maps each callback data value to parameters in the query string: <code>recipient={{to}}&sender={{from}}&message={{msg}}&id={{uid}}</code>
+Callback URLs use the `POST` method and use token replacements to place callback data values in query string parameters. For example, the following partial query string maps each callback data value to parameters in the query string: `recipient={{to}}&sender={{from}}&message={{msg}}&id={{uid}}`
 
 ## Receive Notify
 
@@ -501,8 +499,8 @@ $ curl --request POST
 // Configure FoneNumber 3215551111 to receive a callback with
 // JSON payload data (application/json) to url https://hookb.in/vDkMOVB9
 // when a message is received.
-var FracTelApi211 = require('frac_tel_api_211');
-var apiInstance = new FracTelApi211.MessagesApi();
+var FracTelApi212 = require('frac_tel_api_212');
+var apiInstance = new FracTelApi212.MessagesApi();
 var fonenumber = "3215551111";
 var method = "JSON";
 var url = "https://hookb.in/vDkMOVB9";
@@ -618,4 +616,4 @@ from | string | | Phone number of sender.
 message | string | | Contents of the message.
 uid | string | | Unique identifier for the message.
 
-Callback URLs using the `GET` method use token replacements to place callback data values in query string parameters. For example, the following partial query string maps each callback data value to parameters in the query string: <code>recipient={{to}}&sender={{from}}&message={{msg}}&id={{uid}}</code>
+Callback URLs using the `GET` method use token replacements to place callback data values in query string parameters. For example, the following partial query string maps each callback data value to parameters in the query string: `recipient={{to}}&sender={{from}}&message={{msg}}&id={{uid}}`

--- a/source/includes/_messages.md
+++ b/source/includes/_messages.md
@@ -26,8 +26,8 @@ $ curl --request POST
 // to a recipent 3215552222
 // containing an image https://www.fractel.net/wp-content/uploads/2014/03/FracTEL_Tag_Logo.png
 // with a callback url https://hookb.in/vDkMOVB9
-var FracTelApi212 = require('frac_tel_api_212');
-var apiInstance = new FracTelApi212.MessagesApi();
+var FracTelApi = require('frac_tel_api_212');
+var apiInstance = new FracTelApi.MessagesApi();
 var to = "3215552222";
 var fonenumber = "3215551111";
 var message = "Hello World";
@@ -220,8 +220,8 @@ curl --request POST
 // Configure FoneNumber 3215551111 to receive a callback with
 // POST data (application/x-www-form-urlencoded) to url https://hookb.in/vDkMOVB9
 // when a message is sent.
-var FracTelApi212 = require('frac_tel_api_212');
-var apiInstance = new FracTelApi212.MessagesApi();
+var FracTelApi = require('frac_tel_api_212');
+var apiInstance = new FracTelApi.MessagesApi();
 var fonenumber = "3215551111";
 var method = "POST";
 var url = "https://hookb.in/vDkMOVB9";
@@ -357,8 +357,8 @@ $ curl --request POST
 ```javascript
 // Deliver all messages received by FoneNumber 3215551111
 // to an email address email@domain.
-var FracTelApi212 = require('frac_tel_api_212');
-var apiInstance = new FracTelApi212.MessagesApi();
+var FracTelApi = require('frac_tel_api_212');
+var apiInstance = new FracTelApi.MessagesApi();
 var fonenumber = "3215551111";
 var type = "Email";
 var opts = {
@@ -499,8 +499,8 @@ $ curl --request POST
 // Configure FoneNumber 3215551111 to receive a callback with
 // JSON payload data (application/json) to url https://hookb.in/vDkMOVB9
 // when a message is received.
-var FracTelApi212 = require('frac_tel_api_212');
-var apiInstance = new FracTelApi212.MessagesApi();
+var FracTelApi = require('frac_tel_api_212');
+var apiInstance = new FracTelApi.MessagesApi();
 var fonenumber = "3215551111";
 var method = "JSON";
 var url = "https://hookb.in/vDkMOVB9";

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1,5 +1,5 @@
 ---
-title: FoneStorm API 2.1.1
+title: FoneStorm API 2.1.2
 
 language_tabs:
   - shell: cURL


### PR DESCRIPTION
* Changed example requests to use example FoneNumber _3215551111_
* Added a **Response Properties** table for each route.
  * We considered using comments next response examples, but that breaks the JSON syntax highlighting, because [comments in JSON is not valid markup](https://stackoverflow.com/questions/244777/can-comments-be-used-in-json).
* Updated use of `FoneNumber` in some places where it was previously missed.

The updates can be reviewed on [dev-docs website](https://dev-docs.fractel.net/) please review. 